### PR TITLE
Lore and docs organization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# We can break this out when we have more than one team for the org
+* @our-stories/lore-keepers

--- a/README.md
+++ b/README.md
@@ -46,34 +46,18 @@ The Wilderness has begun stirring. And although the sensible townsfolk keep watc
 * **What is the scale of the game?** This is really open ended. The nature of a West Marches game does lend itself to be centered around Waldenstone. This is not a normal campaign that has the luxury to delve into nuanced areas...Yet. Perhaps it will change.
 * **Is there some sort of chat I can join?** You betcha. I would prefer most permanent lore/session/character chatter end up here on GitHub. But for realtime chat, feel free to join us on [discord](https://discord.gg/m8fu5US).
 
-## How to start a character
+## Questions?
 
-1. See the character creation guidelines (coming soon) for building a character.
+Check out the [docs folder](docs/) for documentation on:
 
-2. Submit [a character issue](https://github.com/our-stories/west-marches/issues/new?assignees=&labels=character%2Cunapproved&template=character.md&title=Character%3A+NAME+OF+CHARACTER). A game master will work with you in the comments to sort out any character building questions and issues.
+* [How to create a character](docs/how-do-i/create-a-character.md)
+* [How to schedule a session](docs/how-do-i/schedule-a-session.md)
+* [Giving Feedback]()
+* [Experience and Levels]()
+* [Contributing]()
+* []()
+* []()
 
-3. After that's is completed and approved, [create a wiki page](https://github.com/our-stories/west-marches/wiki/_new) with your character information.
-
-You are welcome to create as many characters as you would like, but you can only choose a single character for each session.
-
-## How to schedule a session
-
-Each session will need to be scheduled. For every session, a player in the party should [begin a session issue](https://github.com/our-stories/west-marches/issues/new?assignees=&labels=session&template=session.md&title=Session%3A+SOMETHING+WITTY) filling out as many details as possible.
-
-Each session can only have between 2-4 players (excluding the Game Master). Once the scheduling details are sorted out, the Game Master will offer a couple places for explorations. If this is the first time the characters have met each other, the party can use the issue comments to role play introductions. That way we can dive into the exploration early in the session.
-
-If the party is scheduling a continuation from a previous session, include a link and details where the party left off. Continuations do not need the same party composition as long as 2/3rd of players from the previous session are okay with it continuing.
-
-Expectations for a session:
-
-* **Be 15 minutes early.** This helps the party start on time. It's also fun to break the ice. The game will go a lot smoother.
-* **Video chat is required.** We will use audio **and** video for our session.
-
-## After a session ends
-
-After a session ends, every character that participated needs to submit a short recap of the session from their character's point of view. A few sentences will do.
-
-Experience points (XP) will be awarded to all characters to track on their characters. Updates to the character's wiki are appreciated as it will help us for new sessions.
 
 ## I have thoughts that I would prefer to share anonymously
 

--- a/docs/experience-and-levels.md
+++ b/docs/experience-and-levels.md
@@ -1,0 +1,7 @@
+# Experience
+
+We are playing using experience. The XP characters earn will be posted in the session issue after each session is completed. XP should be granted for all encounters that are overcome, regardless of how. Talking an ogre out of a fight worth just as much xp as defeating them in combat or sneaking through their camp (provided that it's not resolved by a single roll and there is some action/drama).
+
+# Levels
+
+Leveling up occurs after you have enough xp and take a long rest. This will almost always happen after a session, but if you get enough xp and the adventures continues into another session where there is not a long rest you won't level until you can rest or the adventure completes and a rest is assumed.

--- a/docs/how-do-i/contribute-content.md
+++ b/docs/how-do-i/contribute-content.md
@@ -1,0 +1,17 @@
+# Contributing Lore and Setting Information
+
+The town of Waldenstone is a growing, thriving community with many mysteries to be discovered. We welcome input from everyone! If you have an idea we'd love to hear it. Everyone is welcome to write up some lore to create suggestions of lore that they'd love to see, but haven't written. 
+
+### Contributing Lore
+
+To add some lore create a Pull Request creating and/or updating files in [the setting folder](../../setting/). One of the `Lore Keepers` will review and approve the Pull Request to ensure that it doesn't conflict with existing lore or create any problems. If it does conflict, do not worry, the `Lore Keepers` will work with you to update either your new content or the existing content to resolve the conflict or concern.
+
+### Contributing Ideas
+
+Not sure how to create a Pull Request, don't have time to flesh the idea out or not sure how it should get fleshed out? No problem! You can create an issue or discussion and work on it in there with anyone else who is interested.
+
+# Character Viewpoints
+
+# NPC Viewpoints
+
+# Allow Characters to be NPCs

--- a/docs/how-do-i/create-a-character.md
+++ b/docs/how-do-i/create-a-character.md
@@ -1,0 +1,11 @@
+# How to start a character
+
+1. See the character creation guidelines (coming soon) for building a character.
+
+2. Submit [a character issue](https://github.com/our-stories/west-marches/issues/new?assignees=&labels=character%2Cunapproved&template=character.md&title=Character%3A+NAME+OF+CHARACTER). A game master will work with you in the comments to sort out any character building questions and issues.
+
+3. After that's is completed and approved, [create a wiki page](https://github.com/our-stories/west-marches/wiki/_new) with your character information.
+
+You are welcome to create as many characters as you would like, but you can only choose a single character for each session. Most characters started out at level 3, but you are welcome to make a character of any level (no guarantees that there will be a spot for your level 20 when everyone else is level 5 though.) All officially published materials are allowed. 
+
+If you are storing your character in dndbeyond.com, you are encouraged to join one of the campaigns for the game there where you will have access to all materials owned by the players (which should be basically everything). There will eventually be more than 1 campaign there as there is a limit of 12 players per campaign and we'll likely end up with more. You can ask in discord for an invite link to a campaign.

--- a/docs/how-do-i/schedule-a-session.md
+++ b/docs/how-do-i/schedule-a-session.md
@@ -1,0 +1,18 @@
+# How to schedule a session
+
+Each session will need to be scheduled. For every session, a player in the party should [begin a session issue](https://github.com/our-stories/west-marches/issues/new?assignees=&labels=session&template=session.md&title=Session%3A+SOMETHING+WITTY) filling out as many details as possible.
+
+Each session can only have between 2-4 players (excluding the Game Master). Once the scheduling details are sorted out, the Game Master will offer a couple places for explorations. If this is the first time the characters have met each other, the party can use the issue comments to role play introductions. That way we can dive into the exploration early in the session.
+
+If the party is scheduling a continuation from a previous session, include a link and details where the party left off. Continuations do not need the same party composition as long as 2/3rd of players from the previous session are okay with it continuing.
+
+Expectations for a session:
+
+* **Be 15 minutes early.** This helps the party start on time. It's also fun to break the ice. The game will go a lot smoother.
+* **Video chat is required.** We will use audio **and** video for our session.
+
+## After a session ends
+
+After a session ends, every character that participated needs to submit a short recap of the session from their character's point of view. A few sentences will do.
+
+Experience points (XP) will be awarded to all characters to track on their characters. Updates to the character's wiki are appreciated as it will help us for new sessions.


### PR DESCRIPTION
This PR moves the content from the wiki to the repo so it can be tracked. It's also a refactor of the content in the readme into individual docs, hopefully making it easier to find things. I'm still actively working on it (hence the draft PR status), but I'm happy to hear any feedback.

It will also prepare the way for the `main` branch to be protected so that you cannot push directly to it and any PRs require a review before merging. This does a few things, first, it creates a clearer trail of what changed, when it changed and why it changed. Second, it also will help to ensure that people are able to keep up to date with changes and that at least one other person was aware of a change before it was added.

- [ ] Enable branch protection
- [ ] Update all the docs
- [ ] Move content from wiki to repo
- [ ] Update issue templates
- [ ] Better guidance around issues vs discussions for lore and other things
- [ ] Linting of markdown files via CI?